### PR TITLE
Update connector name to include a character compatible with `trim()`

### DIFF
--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -81,7 +81,7 @@ describe('MetamaskWallet', () => {
   describe('constructor', () => {
     it('should initialize with correct properties', () => {
       expect(wallet.version).toBe('1.0.0');
-      expect(wallet.name).toBe('MetaMask‎');
+      expect(wallet.name).toBe('MetaMask\uFEFF');
       expect(wallet.icon).toBeDefined();
       expect(wallet.chains).toContain(SOLANA_MAINNET_CHAIN);
       expect(wallet.accounts).toEqual([]);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -60,7 +60,7 @@ export class MetamaskWalletAccount extends ReadonlyWalletAccount {
 export class MetamaskWallet implements Wallet {
   readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
   readonly version = '1.0.0' as const;
-  readonly name = 'MetaMask‎' as const;
+  readonly name = 'MetaMask\uFEFF' as const;
   readonly icon = metamaskIcon;
   readonly chains: SolanaChain[] = [SOLANA_MAINNET_CHAIN, SOLANA_DEVNET_CHAIN, SOLANA_TESTNET_CHAIN];
   #scope: Scope | undefined;

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -60,6 +60,8 @@ export class MetamaskWalletAccount extends ReadonlyWalletAccount {
 export class MetamaskWallet implements Wallet {
   readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
   readonly version = '1.0.0' as const;
+  // Using U+FEFF (zero-width no-break space) to avoid conflicts with Solflare connector using MetaMask Snap.
+  // This character ensures the name matches "MetaMask" when using trim()
   readonly name = 'MetaMask\uFEFF' as const;
   readonly icon = metamaskIcon;
   readonly chains: SolanaChain[] = [SOLANA_MAINNET_CHAIN, SOLANA_DEVNET_CHAIN, SOLANA_TESTNET_CHAIN];


### PR DESCRIPTION
# Description

In order to simplify aggregation of EVM and Solana connectors on Multichain dapps, we want the Wallet Standard connector name to match "MetaMask" when using `trim()`.

The previously used invisible character was `U+200E`. However this character isn't removed when using `trim`.

This PR replaces this character by `U+FEFF`, a zero-width no-break space, specified as a [white space character in Js docs](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Lexical_grammar#white_space), thus supported by trim()

# How to test

`"Hello\uFEFF".trim() === "Hello"` -> should returns true