### PR TITLE
fix: update #disconnect to not revoke session on Solana disconnect via account changed event

### DIFF
--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -476,7 +476,7 @@ describe('MetamaskWallet', () => {
   });
 
   describe('handleAccountsChangedEvent', () => {
-    it('should disconnect when no address is provided', async () => {
+    it('should disconnect without revoking session when no address is provided', async () => {
       await connectAndSetAccount();
 
       // Setup account change listener
@@ -495,7 +495,7 @@ describe('MetamaskWallet', () => {
 
       // Verify account was removed and disconnect was called
       expect(wallet.accounts).toEqual([]);
-      expect(mockClient.revokeSession).toHaveBeenCalled();
+      expect(mockClient.revokeSession).not.toHaveBeenCalled();
       expect(changeListener).toHaveBeenCalledWith({ accounts: [] });
     });
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -355,6 +355,8 @@ export class MetamaskWallet implements Wallet {
 
     // If no address is provided, disconnect
     if (!addressToSelect) {
+      // An empty accountsChanged event means that the Solana scope was revoked outside of Wallet Standard.
+      // We don't revoke the session in this case to avoid side effects on EVM scopes
       await this.#disconnect({ revokeSession: false });
       return;
     }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -222,13 +222,16 @@ export class MetamaskWallet implements Wallet {
     return results;
   };
 
-  #disconnect = async () => {
+  #disconnect = async (options: { revokeSession?: boolean } = {}) => {
+    const { revokeSession = true } = options;
     this.#account = undefined;
     this.scope = undefined;
     this.#removeAccountsChangedListener?.();
     this.#removeAccountsChangedListener = undefined;
     this.#emit('change', { accounts: this.accounts });
-    await this.client.revokeSession();
+    if (revokeSession) {
+      await this.client.revokeSession();
+    }
   };
 
   #signAndSendTransaction = async (
@@ -352,11 +355,7 @@ export class MetamaskWallet implements Wallet {
 
     // If no address is provided, disconnect
     if (!addressToSelect) {
-      console.log('No address to select, disconnecting');
-
-      await this.#disconnect();
-      console.log('this.accounts', this.accounts);
-
+      await this.#disconnect({ revokeSession: false });
       return;
     }
 


### PR DESCRIPTION
## **Description**

This PR updates the disconnect logic to not revoke the session when called from an account changed event, while still revoking the session when called from the `StandardDisconnect` feature.

It fixes a bug where EVM scopes where being disconnected when removing all the Solana accounts from a session in MetaMask.

## **Manual testing steps**

1. Go to https://metamask.github.io/test-dapp-solana/staging/
2. Connect with both an EVM and a Solana account
3. Disconnect the Solana account from MetaMask by editing the permissions 
4. EVM account should still be connected


## **Screenshots/Recordings**

### **Before**

https://github.com/user-attachments/assets/5d94e168-167c-4e61-b41f-ed0d72b600ec

### **After**

https://github.com/user-attachments/assets/8f147b29-246d-47d9-a72c-d86523357c7c