### PR TITLE
feat: add wallet_sessionChanged handling for lifecycle events

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Add `wallet_sessionChanged` listener for handling selecting account changes and for auto connecting and disconnecting the provider when session changes are initiated outside of the provider itself ([#65](https://github.com/MetaMask/solana-wallet-standard/pull/65))
+
+### Removed
+- Remove `metamask_accountsChanged` listener [#65](https://github.com/MetaMask/solana-wallet-standard/pull/65)
+
+
 ## [0.6.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,11 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+
 - Add `wallet_sessionChanged` listener for handling selecting account changes and for auto connecting and disconnecting the provider when session changes are initiated outside of the provider itself ([#65](https://github.com/MetaMask/solana-wallet-standard/pull/65))
 
 ### Removed
-- Remove `metamask_accountsChanged` listener [#65](https://github.com/MetaMask/solana-wallet-standard/pull/65)
 
+- Remove `metamask_accountsChanged` listener [#65](https://github.com/MetaMask/solana-wallet-standard/pull/65)
 
 ## [0.6.0]
 

--- a/package.json
+++ b/package.json
@@ -87,6 +87,8 @@
     "allowScripts": {
       "@lavamoat/preinstall-always-fail": false,
       "vite>esbuild": false,
+      "vitest>vite>esbuild": false,
+      "vitest>vite-node>vite>esbuild": false,
       "@biomejs/biome": false
     }
   }

--- a/src/utils.test.ts
+++ b/src/utils.test.ts
@@ -1,5 +1,6 @@
+import type { SessionData } from '@metamask/multichain-api-client';
 import { describe, expect, it } from 'vitest';
-import { getAddressFromCaipAccountId } from './utils';
+import { getAddressFromCaipAccountId, isSessionChangedEvent } from './utils';
 
 describe('getAddressFromCaipAccountId', () => {
   it('should return the account address for a valid CAIP-10 account ID', () => {
@@ -16,5 +17,27 @@ describe('getAddressFromCaipAccountId', () => {
   it('should throw an error if the chain ID is malformed', () => {
     const malformedChainIdCaipAccountId = 'eip155::0x1234567890abcdef1234567890abcdef12345678';
     expect(() => getAddressFromCaipAccountId(malformedChainIdCaipAccountId)).toThrow('Invalid CAIP account ID.');
+  });
+});
+
+describe('isSessionChangedEvent', () => {
+  const emptySession = { sessionScopes: {} } satisfies SessionData;
+
+  it('returns true for wallet_sessionChanged notifications', () => {
+    const event = { method: 'wallet_sessionChanged', params: emptySession };
+    expect(isSessionChangedEvent(event)).toBe(true);
+    if (isSessionChangedEvent(event)) {
+      expect(event.params.sessionScopes).toEqual({});
+    }
+  });
+
+  it('returns false for other notification shapes', () => {
+    expect(
+      isSessionChangedEvent({
+        params: { notification: { method: 'metamask_accountsChanged', params: [] } },
+      }),
+    ).toBe(false);
+    expect(isSessionChangedEvent({ method: 'other', params: emptySession })).toBe(false);
+    expect(isSessionChangedEvent({})).toBe(false);
   });
 });

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,6 +38,11 @@ export function getScopeFromWalletStandardChain(chainId: CaipChainIdStruct | und
   }
 }
 
+// This isn't checking the scope
 export function isAccountChangedEvent(event: any) {
-  return event.params?.notification?.method === 'metamask_accountsChanged';
+  return isSessionChangedEvent(event) && event.params?.notification?.method === 'metamask_accountsChanged';
+}
+
+export function isSessionChangedEvent(event: any) {
+  return event.method === 'wallet_sessionChanged';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,5 +1,6 @@
 import { SOLANA_DEVNET_CHAIN, SOLANA_MAINNET_CHAIN, SOLANA_TESTNET_CHAIN } from '@solana/wallet-standard-chains';
 import { type CaipAccountId, type CaipChainIdStruct, Scope, scopes } from './types';
+import type { SessionData } from '@metamask/multichain-api-client';
 
 export const CAIP_ACCOUNT_ID_REGEX =
   /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32})):(?<accountAddress>[-.%a-zA-Z0-9]{1,128})$/u;
@@ -38,6 +39,9 @@ export function getScopeFromWalletStandardChain(chainId: CaipChainIdStruct | und
   }
 }
 
-export function isSessionChangedEvent(event: any) {
+export function isSessionChangedEvent(event: any): event is {
+  method: 'wallet_sessionChanged';
+  params: SessionData;
+} {
   return event.method === 'wallet_sessionChanged';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -38,11 +38,6 @@ export function getScopeFromWalletStandardChain(chainId: CaipChainIdStruct | und
   }
 }
 
-// This isn't checking the scope
-export function isAccountChangedEvent(event: any) {
-  return isSessionChangedEvent(event) && event.params?.notification?.method === 'metamask_accountsChanged';
-}
-
 export function isSessionChangedEvent(event: any) {
   return event.method === 'wallet_sessionChanged';
 }

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -1,6 +1,6 @@
+import type { SessionData } from '@metamask/multichain-api-client';
 import { SOLANA_DEVNET_CHAIN, SOLANA_MAINNET_CHAIN, SOLANA_TESTNET_CHAIN } from '@solana/wallet-standard-chains';
 import { type CaipAccountId, type CaipChainIdStruct, Scope, scopes } from './types';
-import type { SessionData } from '@metamask/multichain-api-client';
 
 export const CAIP_ACCOUNT_ID_REGEX =
   /^(?<chainId>(?<namespace>[-a-z0-9]{3,8}):(?<reference>[-_a-zA-Z0-9]{1,32})):(?<accountAddress>[-.%a-zA-Z0-9]{1,128})$/u;

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -511,30 +511,30 @@ describe('MetamaskWallet', () => {
     });
 
     it('should use the selectedAddress if provided and valid', () => {
-      (wallet as any).updateSession(session, address);
+      (wallet as any).updateSession(session);
 
       expect(wallet.accounts[0]?.address).toBe(address);
       expect((wallet as any).scope).toBe(Scope.MAINNET);
     });
 
     it("should default to the first account in the scope if selectedAddress doesn't exists", () => {
-      (wallet as any).updateSession(session, address2);
+      (wallet as any).updateSession(session);
 
       expect(wallet.accounts[0]?.address).toBe(address);
       expect((wallet as any).scope).toBe(Scope.MAINNET);
     });
 
     it('should fall back to the previously saved account if selectedAddress is not provided', () => {
-      (wallet as any).updateSession(session, undefined);
+      (wallet as any).updateSession(session);
 
       const previousAccount = wallet.accounts[0];
-      (wallet as any).updateSession(session, undefined);
+      (wallet as any).updateSession(session);
 
       expect(wallet.accounts[0]).toEqual(previousAccount);
     });
 
     it('should default to the first account in the scope if no selectedAddress or previous account exists', () => {
-      (wallet as any).updateSession(session, undefined);
+      (wallet as any).updateSession(session);
 
       expect(wallet.accounts[0]?.address).toBe(address);
       expect((wallet as any).scope).toBe(Scope.MAINNET);

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -507,7 +507,7 @@ describe('MetamaskWallet', () => {
       expect(changeListener).toHaveBeenCalledWith({ accounts: [] });
     });
 
-    it('updates account and emits change when wallet_sessionChanged includes Solana with a new first account', async () => {
+    it('updates account and emits change when `wallet_sessionChanged` includes a Solana scope with an account value in the 0th index of the accounts array that is different from the previous 0th indexed value', async () => {
       await connectAndSetAccount();
 
       const changeListener = vi.fn();

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -28,17 +28,10 @@ describe('MetamaskWallet', () => {
   let mockClient: ReturnType<typeof createMockClient>;
   let notificationHandler: ReturnType<typeof vi.fn>;
 
-  // Emit account change event
-  const emitAccountChange = (address: string) => {
-    notificationHandler({
-      params: {
-        notification: {
-          method: 'metamask_accountsChanged',
-          params: [address],
-        },
-      },
-    });
-  };
+  const clearedSolanaSessionPayload = () => ({
+    method: 'wallet_sessionChanged' as const,
+    params: { sessionScopes: {} },
+  });
 
   const setupNotificationHandler = () => {
     notificationHandler = vi.fn();
@@ -51,12 +44,7 @@ describe('MetamaskWallet', () => {
     mockCreateSession(mockClient, [_address]);
     setupNotificationHandler();
 
-    const connectPromise = wallet.features[StandardConnect].connect();
-
-    // Emit account change event
-    emitAccountChange(_address);
-
-    return connectPromise;
+    return wallet.features[StandardConnect].connect();
   };
 
   // Helper to connect wallet and set account
@@ -64,20 +52,13 @@ describe('MetamaskWallet', () => {
     mockGetSession(mockClient, [_address]);
     setupNotificationHandler();
 
-    const connectPromise = wallet.features[StandardConnect].connect();
-
-    // Emit account change event
-    emitAccountChange(_address);
-
-    return connectPromise;
+    return wallet.features[StandardConnect].connect();
   };
 
   beforeEach(() => {
     vi.clearAllMocks();
     mockClient = createMockClient();
     wallet = new MetamaskWallet({ client: mockClient, walletName: 'MetaMask Test' });
-    // Mock #getInitialSelectedAddress private method to resolve immediately with undefined
-    vi.spyOn(MetamaskWallet.prototype as any, 'getInitialSelectedAddress').mockResolvedValue(undefined);
   });
 
   describe('constructor', () => {
@@ -355,9 +336,6 @@ describe('MetamaskWallet', () => {
         statement: 'Sign in to test app',
       });
 
-      // Simulate accountsChanged event to complete connection
-      emitAccountChange(address);
-
       const results = await signInPromise;
 
       // Verify signIn was called
@@ -483,15 +461,7 @@ describe('MetamaskWallet', () => {
       const changeListener = vi.fn();
       wallet.features[StandardEvents].on('change', changeListener);
 
-      // Simulate accountsChanged event with no address
-      await notificationHandler({
-        params: {
-          notification: {
-            method: 'metamask_accountsChanged',
-            params: [],
-          },
-        },
-      });
+      await notificationHandler(clearedSolanaSessionPayload());
 
       // Verify account was removed and disconnect was called
       expect(wallet.accounts).toEqual([]);
@@ -500,12 +470,11 @@ describe('MetamaskWallet', () => {
     });
 
     it('should use address from getInitialSelectedAddress', async () => {
-      // Mocks
-      vi.spyOn(MetamaskWallet.prototype as any, 'getInitialSelectedAddress').mockResolvedValue(address2);
-      mockCreateSession(mockClient, [address, address2]);
-      mockGetSession(mockClient, [address, address2]);
+      // Mocks: first account in session is used (replaces legacy getInitialSelectedAddress selection)
+      mockCreateSession(mockClient, [address2, address]);
+      mockGetSession(mockClient, [address2, address]);
 
-      // Create new wallet with mocked getInitialSelectedAddress
+      // Create new wallet
       const walletWithInitialAddress = new MetamaskWallet({ client: mockClient });
 
       // Connect and verify the address from getInitialSelectedAddress was used
@@ -535,7 +504,7 @@ describe('MetamaskWallet', () => {
     });
 
     it('should update account and scope to the first available scope in priority order', () => {
-      (wallet as any).updateSession(session, undefined);
+      (wallet as any).updateSession(session);
 
       expect(wallet.accounts[0]?.address).toBe(address);
       expect((wallet as any).scope).toBe(Scope.MAINNET);
@@ -572,7 +541,7 @@ describe('MetamaskWallet', () => {
     });
 
     it('should set account to undefined if no scopes are available', () => {
-      (wallet as any).updateSession({ sessionScopes: {} }, undefined);
+      (wallet as any).updateSession({ sessionScopes: {} });
 
       expect(wallet.accounts).toEqual([]);
       expect((wallet as any).scope).toBeUndefined();
@@ -585,7 +554,6 @@ describe('MetamaskWallet', () => {
             [Scope.MAINNET]: { accounts: [] },
           },
         },
-        undefined,
       );
 
       expect(wallet.accounts).toEqual([]);
@@ -596,7 +564,7 @@ describe('MetamaskWallet', () => {
       const changeListener = vi.fn();
       wallet.features[StandardEvents].on('change', changeListener);
 
-      (wallet as any).updateSession(session, address);
+      (wallet as any).updateSession(session);
 
       expect(changeListener).toHaveBeenCalledWith({ accounts: wallet.accounts });
     });

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -9,7 +9,7 @@ import {
 import type { WalletAccount } from '@wallet-standard/base';
 import { StandardConnect, StandardDisconnect, StandardEvents } from '@wallet-standard/features';
 import bs58 from 'bs58';
-import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest';
 import {
   mockAddress as address,
   mockAddress2 as address2,
@@ -62,12 +62,41 @@ describe('MetamaskWallet', () => {
   });
 
   describe('constructor', () => {
+    beforeEach(() => {
+      vi.useFakeTimers();
+    });
+
+    afterEach(() => {
+      vi.useRealTimers();
+    });
+
     it('should initialize with correct properties', () => {
       expect(wallet.version).toBe('1.0.0');
       expect(wallet.name).toBe('MetaMask Test');
       expect(wallet.icon).toBeDefined();
       expect(wallet.chains).toContain(SOLANA_MAINNET_CHAIN);
       expect(wallet.accounts).toEqual([]);
+    });
+
+    it('registers wallet_sessionChanged listener and attempts session restore on construction', async () => {
+      const localClient = createMockClient();
+      const w = new MetamaskWallet({ client: localClient, walletName: 'MetaMask Test' });
+
+      expect(localClient.onNotification).toHaveBeenCalledTimes(1);
+      await vi.runAllTimersAsync();
+      expect(localClient.getSession).toHaveBeenCalled();
+      expect(w.accounts).toEqual([]);
+    });
+
+    it('restores Solana account when getSession returns a session during construction', async () => {
+      const localClient = createMockClient();
+      mockGetSession(localClient, [address]);
+      const w = new MetamaskWallet({ client: localClient, walletName: 'MetaMask Test' });
+
+      await vi.runAllTimersAsync();
+
+      expect(w.accounts.length).toBe(1);
+      expect(w.accounts[0]?.address).toBe(address);
     });
 
     it('should initialize with default properties', () => {
@@ -164,6 +193,15 @@ describe('MetamaskWallet', () => {
       expect(wallet.accounts).toEqual([]);
       expect(mockClient.revokeSession).toHaveBeenCalled();
       expect(changeListener).toHaveBeenCalledWith({ accounts: [] });
+    });
+
+    it('should not emit change when disconnecting while already disconnected', async () => {
+      const changeListener = vi.fn();
+      wallet.features[StandardEvents].on('change', changeListener);
+
+      await wallet.features[StandardDisconnect].disconnect();
+
+      expect(changeListener).not.toHaveBeenCalled();
     });
   });
 
@@ -453,8 +491,8 @@ describe('MetamaskWallet', () => {
     });
   });
 
-  describe('handleAccountsChangedEvent', () => {
-    it('should disconnect without revoking session when no address is provided', async () => {
+  describe('handleSessionChangedEvent', () => {
+    it('should disconnect without revoking session when session has no Solana scopes', async () => {
       await connectAndSetAccount();
 
       // Setup account change listener
@@ -467,6 +505,49 @@ describe('MetamaskWallet', () => {
       expect(wallet.accounts).toEqual([]);
       expect(mockClient.revokeSession).not.toHaveBeenCalled();
       expect(changeListener).toHaveBeenCalledWith({ accounts: [] });
+    });
+
+    it('updates account and emits change when wallet_sessionChanged includes Solana with a new first account', async () => {
+      await connectAndSetAccount();
+
+      const changeListener = vi.fn();
+      wallet.features[StandardEvents].on('change', changeListener);
+
+      await notificationHandler({
+        method: 'wallet_sessionChanged' as const,
+        params: {
+          sessionScopes: {
+            [Scope.MAINNET]: {
+              accounts: [`${Scope.MAINNET}:${address2}`],
+              methods: [],
+              notifications: [],
+            },
+          },
+        },
+      });
+
+      expect(wallet.accounts[0]?.address).toBe(address2);
+      expect(changeListener).toHaveBeenCalledWith({ accounts: wallet.accounts });
+    });
+
+    it('ignores non-wallet_sessionChanged notifications', async () => {
+      await connectAndSetAccount();
+
+      const changeListener = vi.fn();
+      wallet.features[StandardEvents].on('change', changeListener);
+      changeListener.mockClear();
+
+      await notificationHandler({
+        params: {
+          notification: {
+            method: 'metamask_accountsChanged',
+            params: [address2],
+          },
+        },
+      });
+
+      expect(wallet.accounts[0]?.address).toBe(address);
+      expect(changeListener).not.toHaveBeenCalled();
     });
 
     it('should use address from getInitialSelectedAddress', async () => {
@@ -565,6 +646,17 @@ describe('MetamaskWallet', () => {
       (wallet as any).updateSession(session);
 
       expect(changeListener).toHaveBeenCalledWith({ accounts: wallet.accounts });
+    });
+
+    it('should not emit change when updateSession keeps the same account address', () => {
+      const changeListener = vi.fn();
+      wallet.features[StandardEvents].on('change', changeListener);
+
+      (wallet as any).updateSession(session);
+      changeListener.mockClear();
+      (wallet as any).updateSession(session);
+
+      expect(changeListener).not.toHaveBeenCalled();
     });
   });
 });

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -28,7 +28,7 @@ describe('MetamaskWallet', () => {
   let mockClient: ReturnType<typeof createMockClient>;
   let notificationHandler: ReturnType<typeof vi.fn>;
 
-  const clearedSolanaSessionPayload = () => ({
+  const emptySolanaSessionPayload = () => ({
     method: 'wallet_sessionChanged' as const,
     params: { sessionScopes: {} },
   });
@@ -499,7 +499,7 @@ describe('MetamaskWallet', () => {
       const changeListener = vi.fn();
       wallet.features[StandardEvents].on('change', changeListener);
 
-      await notificationHandler(clearedSolanaSessionPayload());
+      await notificationHandler(emptySolanaSessionPayload());
 
       // Verify account was removed and disconnect was called
       expect(wallet.accounts).toEqual([]);

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -550,16 +550,14 @@ describe('MetamaskWallet', () => {
       expect(changeListener).not.toHaveBeenCalled();
     });
 
-    it('should use address from getInitialSelectedAddress', async () => {
-      // Mocks: first account in session is used (replaces legacy getInitialSelectedAddress selection)
+    it('should use the first account in the session when multiple accounts are permissioned', async () => {
+      // `updateSession` takes the first CAIP account on the highest-priority Solana scope; list address2 first.
       mockCreateSession(mockClient, [address2, address]);
       mockGetSession(mockClient, [address2, address]);
 
-      // Create new wallet
-      const walletWithInitialAddress = new MetamaskWallet({ client: mockClient });
+      const walletWithMultipleAccounts = new MetamaskWallet({ client: mockClient });
 
-      // Connect and verify the address from getInitialSelectedAddress was used
-      const result = await walletWithInitialAddress.features[StandardConnect].connect();
+      const result = await walletWithMultipleAccounts.features[StandardConnect].connect();
       expect(result.accounts[0]?.address).toBe(address2);
     });
   });

--- a/src/wallet.test.ts
+++ b/src/wallet.test.ts
@@ -548,13 +548,11 @@ describe('MetamaskWallet', () => {
     });
 
     it('should set account to undefined if the scope has no accounts', () => {
-      (wallet as any).updateSession(
-        {
-          sessionScopes: {
-            [Scope.MAINNET]: { accounts: [] },
-          },
+      (wallet as any).updateSession({
+        sessionScopes: {
+          [Scope.MAINNET]: { accounts: [] },
         },
-      );
+      });
 
       expect(wallet.accounts).toEqual([]);
       expect((wallet as any).scope).toBeUndefined();

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -157,8 +157,6 @@ export class MetamaskWallet implements Wallet {
       return { accounts: [] };
     }
 
-    // I think it would be better if these were always listening
-    // Problem is that the MultichainApi Transports clear all listeners on disconnect
     this.#removeSessionChangedListener = this.client.onNotification(this.#handleSessionChangedEvent.bind(this));
     return { accounts: this.accounts };
   };

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -206,12 +206,12 @@ export class MetamaskWallet implements Wallet {
     const { revokeSession = true } = options;
     this.#account = undefined;
     this.scope = undefined;
-    this.#removeSessionChangedListener?.();
-    this.#removeSessionChangedListener = undefined;
     if (wasConnected) {
       this.#emit('change', { accounts: this.accounts });
     }
     if (revokeSession) {
+      this.#removeSessionChangedListener?.();
+      this.#removeSessionChangedListener = undefined;
       await this.client.revokeSession({ scopes: [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET] });
     }
   };
@@ -385,7 +385,7 @@ export class MetamaskWallet implements Wallet {
     const previousAccount = this.#account;
     this.#account = this.#getAccountFromAddress(addressToConnect);
     this.scope = scope;
-    if (this.#account !== previousAccount) {
+    if (this.#account.address !== previousAccount?.address) {
       this.#emit('change', { accounts: this.accounts });
     }
   }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -337,13 +337,7 @@ export class MetamaskWallet implements Wallet {
     const hasSolanaScope = sessionScopes.some((scope) => solanaScopes.includes(scope as Scope));
 
     if (hasSolanaScope) {
-      const selectedCaipAccountId: CaipAccountId | undefined =
-        (data.params.sessionScopes[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-        (data.params.sessionScopes[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-        (data.params.sessionScopes[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
-      const selectedAddress = selectedCaipAccountId ? getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
-      const session = await this.client.getSession();
-      this.updateSession(session, selectedAddress);
+      const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(data.params.sessionScopes);
     } else {
       // Only do this if we aren't already disconnected???
 
@@ -401,7 +395,7 @@ export class MetamaskWallet implements Wallet {
     }
     // Otherwise select first account
     else {
-      addressToConnect = getAddressFromCaipAccountId(scopeAccounts[0]);
+      addressToConnect = this.#getAddressFromCaipAccountId(scopeAccounts[0] as CaipAccountId);
     }
 
     // Update the account and scope
@@ -416,6 +410,18 @@ export class MetamaskWallet implements Wallet {
       publicKey: new Uint8Array(bs58.decode(address)),
       chains: this.chains,
     });
+  }
+
+  #getAddressFromCaipAccountId(caipAccountId: CaipAccountId): string {
+    return getAddressFromCaipAccountId(caipAccountId);
+  }
+
+  #getSelectedSolanaAddressFromSessionScopes(sessionScopes: SessionData['sessionScopes'] | undefined): string | undefined {
+    const selectedCaipAccountId: CaipAccountId | undefined =
+      (sessionScopes?.[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+      (sessionScopes?.[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+      (sessionScopes?.[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
+    return selectedCaipAccountId ? this.#getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
   }
 
   #validateSendTransactionInput = (inputs: SolanaSignAndSendTransactionInput[]) => {
@@ -445,13 +451,7 @@ export class MetamaskWallet implements Wallet {
         return;
       }
 
-      const selectedCaipAccountId: CaipAccountId | undefined =
-        (existingSession?.sessionScopes[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-        (existingSession?.sessionScopes[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-        (existingSession?.sessionScopes[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
-      const selectedAddress = selectedCaipAccountId ? getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
-
-
+      const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(existingSession?.sessionScopes);
       this.updateSession(existingSession, selectedAddress);
     } catch (error) {
       console.warn('Error restoring session', error);
@@ -474,12 +474,7 @@ export class MetamaskWallet implements Wallet {
       },
     });
 
-      const selectedCaipAccountId: CaipAccountId | undefined =
-        (session?.sessionScopes[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-        (session?.sessionScopes[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-        (session?.sessionScopes[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
-      const selectedAddress = selectedCaipAccountId ? getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
-
+    const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(session?.sessionScopes);
     this.updateSession(session, selectedAddress);
   };
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -161,7 +161,6 @@ export class MetamaskWallet implements Wallet {
       return { accounts: [] };
     }
 
-
     this.#removeSessionChangedListener?.();
     this.#removeSessionChangedListener = this.client.onNotification(this.#handleSessionChangedEvent.bind(this));
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -40,7 +40,12 @@ import { ReadonlyWalletAccount } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
 import { metamaskIcon } from './icon';
 import { type CaipAccountId, type DeepWriteable, Scope, type WalletOptions } from './types';
-import { getAddressFromCaipAccountId, getScopeFromWalletStandardChain, isAccountChangedEvent } from './utils';
+import {
+  getAddressFromCaipAccountId,
+  getScopeFromWalletStandardChain,
+  isAccountChangedEvent,
+  isSessionChangedEvent,
+} from './utils';
 
 export class MetamaskWalletAccount extends ReadonlyWalletAccount {
   constructor({ address, publicKey, chains }: { address: string; publicKey: Uint8Array; chains: IdentifierArray }) {
@@ -67,6 +72,7 @@ export class MetamaskWallet implements Wallet {
   #selectedAddressOnPageLoadPromise: Promise<string | undefined> | undefined;
   #account: MetamaskWalletAccount | undefined;
   #removeAccountsChangedListener: (() => void) | undefined;
+  #removeSessionChangedListener: (() => void) | undefined;
 
   client: MultichainApiClient;
 
@@ -184,7 +190,10 @@ export class MetamaskWallet implements Wallet {
       return { accounts: [] };
     }
 
+    // I think it would be better if these were always listening
+    // Problem is that the MultichainApi Transports clear all listeners on disconnect
     this.#removeAccountsChangedListener = this.client.onNotification(this.#handleAccountsChangedEvent.bind(this));
+    this.#removeSessionChangedListener = this.client.onNotification(this.#handleSessionChangedEvent.bind(this));
     return { accounts: this.accounts };
   };
 
@@ -228,6 +237,8 @@ export class MetamaskWallet implements Wallet {
     this.scope = undefined;
     this.#removeAccountsChangedListener?.();
     this.#removeAccountsChangedListener = undefined;
+    this.#removeSessionChangedListener?.();
+    this.#removeSessionChangedListener = undefined;
     this.#emit('change', { accounts: this.accounts });
     if (revokeSession) {
       await this.client.revokeSession({ scopes: [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET] });
@@ -341,6 +352,31 @@ export class MetamaskWallet implements Wallet {
 
     return results;
   };
+
+  /**
+   * Handles the wallet_sessionChanged event.
+   * Updates internal state to connected (with correct change event) when the session has Solana scopes,
+   * or to disconnected when it does not.
+   * @param data - The event data
+   */
+  async #handleSessionChangedEvent(data: any) {
+    if (!isSessionChangedEvent(data)) {
+      return;
+    }
+
+    const sessionScopes = Object.keys(data.params.sessionScopes);
+    const solanaScopes = [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET];
+    const hasSolanaScope = sessionScopes.some((scope) => solanaScopes.includes(scope as Scope));
+
+    if (hasSolanaScope) {
+      // Only do this if we aren't already connected?
+      const session = await this.client.getSession();
+      this.updateSession(session, undefined); // not sure what account address to use here
+    } else {
+      // Only do this if we aren't already disconnected?
+      await this.#disconnect({ revokeSession: false });
+    }
+  }
 
   /**
    * Handles the accountsChanged event.

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -433,8 +433,10 @@ export class MetamaskWallet implements Wallet {
         },
       },
       sessionProperties: {
-        // This is still needed to help the wallet identify our injected solana provider.
-        // It isn't needed any longer for enabling metamask_accountsChanged events.
+        // Previously this was needed to enable metamask_accountsChanged events for Solana.
+        // This isn't needed for that purpose since we now use wallet_sessionChanged events.
+        // However this is still needed to help the wallet identify our injected solana provider
+        // until we migrate to a more accurate property name.
         solana_accountChanged_notifications: true,
       },
     });

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -200,12 +200,15 @@ export class MetamaskWallet implements Wallet {
   };
 
   #disconnect = async (options: { revokeSession?: boolean } = {}) => {
+    const wasConnected = Boolean(this.#account);
     const { revokeSession = true } = options;
     this.#account = undefined;
     this.scope = undefined;
     this.#removeSessionChangedListener?.();
     this.#removeSessionChangedListener = undefined;
-    this.#emit('change', { accounts: this.accounts });
+    if (wasConnected) {
+      this.#emit('change', { accounts: this.accounts });
+    }
     if (revokeSession) {
       await this.client.revokeSession({ scopes: [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET] });
     }
@@ -377,9 +380,12 @@ export class MetamaskWallet implements Wallet {
     const addressToConnect = getAddressFromCaipAccountId(selectedAccountId);
 
     // Update the account and scope
+    const previousAccount = this.#account;
     this.#account = this.#getAccountFromAddress(addressToConnect);
     this.scope = scope;
-    this.#emit('change', { accounts: this.accounts });
+    if (this.#account !== previousAccount) {
+      this.#emit('change', { accounts: this.accounts });
+    }
   }
 
   #getAccountFromAddress(address: string) {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -445,6 +445,7 @@ export class MetamaskWallet implements Wallet {
         // This isn't needed for that purpose since we now use wallet_sessionChanged events.
         // However this is still needed to help the wallet identify our injected solana provider
         // until we migrate to a more accurate property name.
+        // See: https://github.com/MetaMask/metamask-extension/blob/70dd748af54b58ceb8e78d227b6bdf118fb8e7ba/ui/pages/multichain-accounts/multichain-accounts-connect-page/multichain-accounts-connect-page.tsx#L169-L174
         solana_accountChanged_notifications: true,
       },
     });

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -40,11 +40,7 @@ import { ReadonlyWalletAccount } from '@wallet-standard/wallet';
 import bs58 from 'bs58';
 import { metamaskIcon } from './icon';
 import { type CaipAccountId, type DeepWriteable, Scope, type WalletOptions } from './types';
-import {
-  getAddressFromCaipAccountId,
-  getScopeFromWalletStandardChain,
-  isSessionChangedEvent,
-} from './utils';
+import { getAddressFromCaipAccountId, getScopeFromWalletStandardChain, isSessionChangedEvent } from './utils';
 
 export class MetamaskWalletAccount extends ReadonlyWalletAccount {
   constructor({ address, publicKey, chains }: { address: string; publicKey: Uint8Array; chains: IdentifierArray }) {
@@ -378,7 +374,7 @@ export class MetamaskWallet implements Wallet {
       return;
     }
 
-  const addressToConnect = getAddressFromCaipAccountId(selectedAccountId);
+    const addressToConnect = getAddressFromCaipAccountId(selectedAccountId);
 
     // Update the account and scope
     this.#account = this.#getAccountFromAddress(addressToConnect);

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -333,8 +333,6 @@ export class MetamaskWallet implements Wallet {
     if (hasSolanaScope) {
       this.updateSession(data.params);
     } else {
-      // Only do this if we aren't already disconnected???
-
       // An empty accountsChanged event means that the Solana scope was revoked outside of Wallet Standard.
       // We don't revoke the session in this case to avoid side effects on EVM scopes
       await this.#disconnect({ revokeSession: false });

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -161,7 +161,10 @@ export class MetamaskWallet implements Wallet {
       return { accounts: [] };
     }
 
+
+    this.#removeSessionChangedListener?.();
     this.#removeSessionChangedListener = this.client.onNotification(this.#handleSessionChangedEvent.bind(this));
+
     return { accounts: this.accounts };
   };
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -43,7 +43,6 @@ import { type CaipAccountId, type DeepWriteable, Scope, type WalletOptions } fro
 import {
   getAddressFromCaipAccountId,
   getScopeFromWalletStandardChain,
-  isAccountChangedEvent,
   isSessionChangedEvent,
 } from './utils';
 
@@ -69,37 +68,10 @@ export class MetamaskWallet implements Wallet {
   readonly icon = metamaskIcon;
   readonly chains: SolanaChain[] = [SOLANA_MAINNET_CHAIN, SOLANA_DEVNET_CHAIN, SOLANA_TESTNET_CHAIN];
   protected scope: Scope | undefined;
-  #selectedAddressOnPageLoadPromise: Promise<string | undefined> | undefined;
   #account: MetamaskWalletAccount | undefined;
-  #removeAccountsChangedListener: (() => void) | undefined;
   #removeSessionChangedListener: (() => void) | undefined;
 
   client: MultichainApiClient;
-
-  /**
-   * Listen for up to 2 seconds to the accountsChanged event emitted on page load
-   * @returns If any, the initial selected address
-   */
-  protected getInitialSelectedAddress(): Promise<string | undefined> {
-    return new Promise((resolve) => {
-      const timeout = setTimeout(() => {
-        resolve(undefined);
-      }, 2000);
-
-      const handleAccountChange = (data: any) => {
-        if (isAccountChangedEvent(data)) {
-          const address = data?.params?.notification?.params?.[0];
-          if (address) {
-            clearTimeout(timeout);
-            removeNotification?.();
-            resolve(address);
-          }
-        }
-      };
-
-      const removeNotification = this.client.onNotification(handleAccountChange);
-    });
-  }
 
   get accounts() {
     return this.#account ? [this.#account] : [];
@@ -149,7 +121,6 @@ export class MetamaskWallet implements Wallet {
   constructor({ client, walletName }: WalletOptions) {
     this.client = client;
     this.name = `${walletName ?? 'MetaMask'}` as const;
-    this.#selectedAddressOnPageLoadPromise = this.getInitialSelectedAddress();
   }
 
   #on: StandardEventsOnMethod = (event, listener) => {
@@ -192,7 +163,6 @@ export class MetamaskWallet implements Wallet {
 
     // I think it would be better if these were always listening
     // Problem is that the MultichainApi Transports clear all listeners on disconnect
-    this.#removeAccountsChangedListener = this.client.onNotification(this.#handleAccountsChangedEvent.bind(this));
     this.#removeSessionChangedListener = this.client.onNotification(this.#handleSessionChangedEvent.bind(this));
     return { accounts: this.accounts };
   };
@@ -235,8 +205,6 @@ export class MetamaskWallet implements Wallet {
     const { revokeSession = true } = options;
     this.#account = undefined;
     this.scope = undefined;
-    this.#removeAccountsChangedListener?.();
-    this.#removeAccountsChangedListener = undefined;
     this.#removeSessionChangedListener?.();
     this.#removeSessionChangedListener = undefined;
     this.#emit('change', { accounts: this.accounts });
@@ -369,36 +337,20 @@ export class MetamaskWallet implements Wallet {
     const hasSolanaScope = sessionScopes.some((scope) => solanaScopes.includes(scope as Scope));
 
     if (hasSolanaScope) {
-      // Only do this if we aren't already connected?
+      const selectedCaipAccountId: CaipAccountId | undefined =
+        (data.params.sessionScopes[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+        (data.params.sessionScopes[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+        (data.params.sessionScopes[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
+      const selectedAddress = selectedCaipAccountId ? getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
       const session = await this.client.getSession();
-      this.updateSession(session, undefined); // not sure what account address to use here
+      this.updateSession(session, selectedAddress);
     } else {
-      // Only do this if we aren't already disconnected?
-      await this.#disconnect({ revokeSession: false });
-    }
-  }
+      // Only do this if we aren't already disconnected???
 
-  /**
-   * Handles the accountsChanged event.
-   * @param data - The event data
-   */
-  async #handleAccountsChangedEvent(data: any) {
-    if (!isAccountChangedEvent(data)) {
-      return;
-    }
-
-    const addressToSelect = data?.params?.notification?.params?.[0];
-
-    // If no address is provided, disconnect
-    if (!addressToSelect) {
       // An empty accountsChanged event means that the Solana scope was revoked outside of Wallet Standard.
       // We don't revoke the session in this case to avoid side effects on EVM scopes
       await this.#disconnect({ revokeSession: false });
-      return;
     }
-
-    const session = await this.client.getSession();
-    this.updateSession(session, addressToSelect);
   }
 
   /**
@@ -408,7 +360,7 @@ export class MetamaskWallet implements Wallet {
    * 1. First tries to find an available scope in order: mainnet > devnet > testnet, supposing the same set of accounts
    *    is available for all Solana scopes
    * 2. For account selection:
-   *    - First tries to use the selectedAddress param, most likely coming from the accountsChanged event
+   *    - First tries to use the selectedAddress param, most likely coming from wallet_sessionChanged
    *    - Falls back to the previously saved account if it exists in the scope
    *    - Finally defaults to the first account in the scope
    *
@@ -493,35 +445,20 @@ export class MetamaskWallet implements Wallet {
         return;
       }
 
-      // Get the account from accountChanged emitted on page load, if any
-      const account = await this.#selectedAddressOnPageLoadPromise;
-      this.updateSession(existingSession, account);
+      const selectedCaipAccountId: CaipAccountId | undefined =
+        (existingSession?.sessionScopes[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+        (existingSession?.sessionScopes[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+        (existingSession?.sessionScopes[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
+      const selectedAddress = selectedCaipAccountId ? getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
+
+
+      this.updateSession(existingSession, selectedAddress);
     } catch (error) {
       console.warn('Error restoring session', error);
     }
   };
 
   #createSession = async (scope: Scope, addresses?: string[]): Promise<void> => {
-    let resolvePromise: (value: string) => void;
-    const waitForAccountChangedPromise = new Promise<string>((resolve) => {
-      resolvePromise = resolve;
-    });
-
-    // If there are multiple accounts, wait for the first accountChanged event to know which one to use
-    const handleAccountChange = (data: any) => {
-      if (!isAccountChangedEvent(data)) {
-        return;
-      }
-      const selectedAddress = data?.params?.notification?.params?.[0];
-
-      if (selectedAddress) {
-        removeNotification();
-        resolvePromise(selectedAddress);
-      }
-    };
-
-    const removeNotification = this.client.onNotification(handleAccountChange);
-
     const session = await this.client.createSession({
       optionalScopes: {
         [scope]: {
@@ -531,15 +468,17 @@ export class MetamaskWallet implements Wallet {
         },
       },
       sessionProperties: {
+        // This is still needed to help the wallet identify our injected solana provider.
+        // It isn't needed any longer for enabling metamask_accountsChanged events.
         solana_accountChanged_notifications: true,
       },
     });
 
-    // Wait for the accountChanged event to know which one to use, timeout after 200ms
-    const selectedAddress = await Promise.race([
-      waitForAccountChangedPromise,
-      new Promise<undefined>((resolve) => setTimeout(() => resolve(undefined), 200)),
-    ]);
+      const selectedCaipAccountId: CaipAccountId | undefined =
+        (session?.sessionScopes[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+        (session?.sessionScopes[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
+        (session?.sessionScopes[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
+      const selectedAddress = selectedCaipAccountId ? getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
 
     this.updateSession(session, selectedAddress);
   };

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -117,6 +117,10 @@ export class MetamaskWallet implements Wallet {
   constructor({ client, walletName }: WalletOptions) {
     this.client = client;
     this.name = `${walletName ?? 'MetaMask'}` as const;
+
+    // TODO: talk with Baptiste and Edouard about this
+    this.#tryRestoringSession();
+    this.#removeSessionChangedListener = this.client.onNotification(this.#handleSessionChangedEvent.bind(this));
   }
 
   #on: StandardEventsOnMethod = (event, listener) => {

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -337,8 +337,7 @@ export class MetamaskWallet implements Wallet {
     const hasSolanaScope = sessionScopes.some((scope) => solanaScopes.includes(scope as Scope));
 
     if (hasSolanaScope) {
-      const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(data.params.sessionScopes);
-      this.updateSession(data.params, selectedAddress);
+      this.updateSession(data.params);
     } else {
       // Only do this if we aren't already disconnected???
 
@@ -351,18 +350,12 @@ export class MetamaskWallet implements Wallet {
   /**
    * Updates the session and the account to connect to.
    * This method handles the logic for selecting the appropriate Solana network scope (mainnet/devnet/testnet)
-   * and account to connect to based on the following priority:
-   * 1. First tries to find an available scope in order: mainnet > devnet > testnet, supposing the same set of accounts
-   *    is available for all Solana scopes
-   * 2. For account selection:
-   *    - First tries to use the selectedAddress param, most likely coming from wallet_sessionChanged
-   *    - Falls back to the previously saved account if it exists in the scope
-   *    - Finally defaults to the first account in the scope
+   * and account to connect to based on the following priority: mainnet > devnet > testnet. It assumes the same
+   * set of accounts is available for all Solana scopes and will take the first account found from the scopes above.
    *
    * @param session - The session data containing available scopes and accounts
-   * @param selectedAddress - The address that was selected by the user, if any
    */
-  protected updateSession(session: SessionData | undefined, selectedAddress: string | undefined) {
+  protected updateSession(session: SessionData | undefined) {
     // Get session scopes
     const sessionScopes = new Set(Object.keys(session?.sessionScopes ?? {}));
 
@@ -375,29 +368,17 @@ export class MetamaskWallet implements Wallet {
       this.#account = undefined;
       return;
     }
-    const scopeAccounts = session?.sessionScopes[scope]?.accounts;
+    const selectedAccountId = session?.sessionScopes[scope]?.accounts?.[0];
 
     // In case the Solana scope is available but without any accounts
     // Could happen if the user already created a session using ethereum injected provider for example or the SDK
     // Don't disconnect so that we can create/update a new session
-    if (!scopeAccounts?.[0]) {
+    if (!selectedAccountId) {
       this.#account = undefined;
       return;
     }
 
-    let addressToConnect;
-    // Try to use selectedAddress
-    if (selectedAddress && scopeAccounts.includes(`${scope}:${selectedAddress}`)) {
-      addressToConnect = selectedAddress;
-    }
-    // Otherwise try to use the previously saved address in this.#account
-    else if (this.#account?.address && scopeAccounts.includes(`${scope}:${this.#account?.address}`)) {
-      addressToConnect = this.#account.address;
-    }
-    // Otherwise select first account
-    else {
-      addressToConnect = this.#getAddressFromCaipAccountId(scopeAccounts[0] as CaipAccountId);
-    }
+  const addressToConnect = getAddressFromCaipAccountId(selectedAccountId);
 
     // Update the account and scope
     this.#account = this.#getAccountFromAddress(addressToConnect);
@@ -411,18 +392,6 @@ export class MetamaskWallet implements Wallet {
       publicKey: new Uint8Array(bs58.decode(address)),
       chains: this.chains,
     });
-  }
-
-  #getAddressFromCaipAccountId(caipAccountId: CaipAccountId): string {
-    return getAddressFromCaipAccountId(caipAccountId);
-  }
-
-  #getSelectedSolanaAddressFromSessionScopes(sessionScopes: SessionData['sessionScopes'] | undefined): string | undefined {
-    const selectedCaipAccountId: CaipAccountId | undefined =
-      (sessionScopes?.[Scope.MAINNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-      (sessionScopes?.[Scope.DEVNET]?.accounts?.[0] as CaipAccountId | undefined) ??
-      (sessionScopes?.[Scope.TESTNET]?.accounts?.[0] as CaipAccountId | undefined);
-    return selectedCaipAccountId ? this.#getAddressFromCaipAccountId(selectedCaipAccountId) : undefined;
   }
 
   #validateSendTransactionInput = (inputs: SolanaSignAndSendTransactionInput[]) => {
@@ -452,8 +421,7 @@ export class MetamaskWallet implements Wallet {
         return;
       }
 
-      const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(existingSession?.sessionScopes);
-      this.updateSession(existingSession, selectedAddress);
+      this.updateSession(existingSession);
     } catch (error) {
       console.warn('Error restoring session', error);
     }
@@ -475,7 +443,6 @@ export class MetamaskWallet implements Wallet {
       },
     });
 
-    const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(session?.sessionScopes);
-    this.updateSession(session, selectedAddress);
+    this.updateSession(session);
   };
 }

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -338,6 +338,7 @@ export class MetamaskWallet implements Wallet {
 
     if (hasSolanaScope) {
       const selectedAddress = this.#getSelectedSolanaAddressFromSessionScopes(data.params.sessionScopes);
+      this.updateSession(data.params, selectedAddress);
     } else {
       // Only do this if we aren't already disconnected???
 

--- a/src/wallet.ts
+++ b/src/wallet.ts
@@ -58,6 +58,9 @@ export class MetamaskWalletAccount extends ReadonlyWalletAccount {
 }
 
 export class MetamaskWallet implements Wallet {
+  // list of scopes in priority order for resolving selected account
+  static readonly scopes = [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET] as const;
+
   readonly #listeners: { [E in StandardEventsNames]?: StandardEventsListeners[E][] } = {};
   readonly version = '1.0.0' as const;
   readonly name;
@@ -212,7 +215,7 @@ export class MetamaskWallet implements Wallet {
     if (revokeSession) {
       this.#removeSessionChangedListener?.();
       this.#removeSessionChangedListener = undefined;
-      await this.client.revokeSession({ scopes: [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET] });
+      await this.client.revokeSession({ scopes: [...MetamaskWallet.scopes] });
     }
   };
 
@@ -336,8 +339,7 @@ export class MetamaskWallet implements Wallet {
     }
 
     const sessionScopes = Object.keys(data.params.sessionScopes);
-    const solanaScopes = [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET];
-    const hasSolanaScope = sessionScopes.some((scope) => solanaScopes.includes(scope as Scope));
+    const hasSolanaScope = sessionScopes.some((scope) => MetamaskWallet.scopes.includes(scope as Scope));
 
     if (hasSolanaScope) {
       this.updateSession(data.params);
@@ -361,8 +363,7 @@ export class MetamaskWallet implements Wallet {
     const sessionScopes = new Set(Object.keys(session?.sessionScopes ?? {}));
 
     // Find the first available scope in priority order: mainnet > devnet > testnet.
-    const scopePriorityOrder = [Scope.MAINNET, Scope.DEVNET, Scope.TESTNET];
-    const scope = scopePriorityOrder.find((scope) => sessionScopes.has(scope));
+    const scope = MetamaskWallet.scopes.find((s) => sessionScopes.has(s));
 
     // If no scope is available, don't disconnect so that we can create/update a new session
     if (!scope) {


### PR DESCRIPTION
Replaces `metamask_accountsChanged` based account/status handling with `wallet_sessionChanged` based handling. The reason `metamask_accountsChanged` events were used before was because Multichain API methods did not return `accounts` ordered by last selected. 

This is changing upstream so that Multichain API methods _do_ return `accounts` ordered by last selected. This change allows us to get rid of our reliance on `metamask_accountsChanged` and simplify our logic. 

This also makes it so that solana connections granted outside of the solana provider (i.e. missing `sessionProperties.solana_metamask_accountsChanged: true`) will also properly work with our solana wallet standard provider. Previously they did not in the scenario above.

See: https://github.com/MetaMask/metamask-extension/pull/41068



<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Updates core connect/disconnect/account-selection behavior to rely on `wallet_sessionChanged`, which could affect wallet state updates and event emissions across consumers if notification shapes or ordering differ in real clients.
> 
> **Overview**
> Switches Solana wallet lifecycle/account tracking from `metamask_accountsChanged` to `wallet_sessionChanged`, including auto-restoring sessions on construction and updating/clearing accounts when Solana scopes are added/removed externally.
> 
> Simplifies `updateSession` to pick the first account from the highest-priority Solana scope (mainnet/devnet/testnet) and avoids emitting `change` events when state doesn’t actually change (including disconnect while already disconnected). Tests and the changelog are updated accordingly, and `lavamoat` config is adjusted to allow `vitest`’s nested `esbuild` scripts.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 11907c744668656eb8bd2d12c4624750aabb51c1. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->