### PR TITLE
chore: migrate npm publishing to trusted publishing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -86,6 +86,7 @@ jobs:
     name: Publish release
     permissions:
       contents: write
+      id-token: write
     uses: ./.github/workflows/publish-release.yml
     secrets:
       NPM_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -9,6 +9,10 @@ on:
         required: true
       PUBLISH_DOCS_TOKEN:
         required: true
+
+permissions:
+  contents: read
+
 jobs:
   publish-release:
     permissions:

--- a/.github/workflows/publish-release.yml
+++ b/.github/workflows/publish-release.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     secrets:
       NPM_TOKEN:
-        required: true
+        required: false
       SLACK_WEBHOOK_URL:
         required: true
       PUBLISH_DOCS_TOKEN:
@@ -48,8 +48,7 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Dry Run Publish
-        # omit npm-token token to perform dry run publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
           slack-webhook-url: ${{ secrets.SLACK_WEBHOOK_URL }}
           subteam: S042S7RE4AE # @metamask-npm-publishers
@@ -60,6 +59,9 @@ jobs:
     needs: publish-npm-dry-run
     runs-on: ubuntu-latest
     environment: npm-publish
+    permissions:
+      contents: read
+      id-token: write
     steps:
       - name: Checkout and setup environment
         uses: MetaMask/action-checkout-and-setup@v1
@@ -71,10 +73,13 @@ jobs:
         with:
           name: publish-release-artifacts-${{ github.sha }}
       - name: Publish
-        uses: MetaMask/action-npm-publish@v5
+        uses: MetaMask/action-npm-publish@v6
         with:
-          # This `NPM_TOKEN` needs to be manually set per-repository.
-          # Look in the repository settings under "Environments", and set this token in the `npm-publish` environment.
+          # This `NPM_TOKEN` needs to be manually set to publish a package for
+          # the first time only.
+          # Look in the repository settings under "Environments", and set this
+          # token in the `npm-publish` environment, and delete it after the
+          # initial publish.
           npm-token: ${{ secrets.NPM_TOKEN }}
         env:
           SKIP_PREPACK: true

--- a/package.json
+++ b/package.json
@@ -75,7 +75,7 @@
     "vite": "^6.2.4",
     "vitest": "^3.0.7"
   },
-  "packageManager": "yarn@4.1.1",
+  "packageManager": "yarn@4.16.0",
   "engines": {
     "node": "^18.20 || ^20.17 || >=22"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,7 +2,7 @@
 # Manual changes might be lost - proceed with caution!
 
 __metadata:
-  version: 8
+  version: 10
   cacheKey: 10
 
 "@ampproject/remapping@npm:^2.2.0":
@@ -4486,11 +4486,11 @@ __metadata:
 
 "typescript@patch:typescript@npm%3A~5.7.3#optional!builtin<compat/typescript>":
   version: 5.7.3
-  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5adc0c"
+  resolution: "typescript@patch:typescript@npm%3A5.7.3#optional!builtin<compat/typescript>::version=5.7.3&hash=5786d5"
   bin:
     tsc: bin/tsc
     tsserver: bin/tsserver
-  checksum: 10/3ac7b7e3e899273d2fbdce6e24b93d4d53a705ad7a7e4cc83b4c57bcb6d25948abcd2a21994f6b9c73ab03960f395aae95f0458de292a66ce0134233261714c3
+  checksum: 10/dc58d777eb4c01973f7fbf1fd808aad49a0efdf545528dab9b07d94fdcb65b8751742804c3057e9619a4627f2d9cc85547fdd49d9f4326992ad0181b49e61d81
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
## Description

Migrates NPM publishing to trusted publishing support via `MetaMask/action-npm-publish@v6`.

Changes:
- Updates publish workflows to use `MetaMask/action-npm-publish@v6`.
- Grants `id-token: write` permission for OIDC-based publishing.
- Makes `NPM_TOKEN` optional in the reusable publish workflow.
- Bumps `packageManager` to `yarn@4.16.0` and regenerates `yarn.lock`.

## Testing

- Validated modified workflow YAML files parse successfully.
- Ran `git diff --check`.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes how packages are authenticated and published on release; misconfiguration could block publishes or briefly rely on a manual NPM_TOKEN for the initial publish.
> 
> **Overview**
> Switches the release pipeline to **npm trusted publishing** by upgrading `MetaMask/action-npm-publish` from v5 to **v6** and enabling **OIDC** (`id-token: write` on the caller `publish-release` job in `main.yml` and on the `publish-npm` job). The reusable workflow now treats **`NPM_TOKEN` as optional** (was required), sets default **`contents: read`**, and documents that the token is only needed for a **first-time** publish before OIDC takes over.
> 
> The dry-run publish step also moves to v6 (replacing the old “omit npm-token for dry run” approach). **`packageManager`** is bumped to **`yarn@4.16.0`** with a regenerated **`yarn.lock`** (lockfile metadata / patch checksum updates only).
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit f731dcaa5629b988cd8a018ceec97f2ce5985e13. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->